### PR TITLE
Allow BeastTreeFromMaster to be re-initialised.

### DIFF
--- a/src/master/BeastTreeFromMaster.java
+++ b/src/master/BeastTreeFromMaster.java
@@ -257,6 +257,9 @@ public class BeastTreeFromMaster extends Tree implements StateNodeInitialiser {
                 youngestLeafTime = leaf.getTime();
             }
         }
+
+        // Reset node array
+        m_nodes = null;
         
         // Create BEAST tree root node:
         beast.evolution.tree.Node beastRoot = new beast.evolution.tree.Node();


### PR DESCRIPTION
`BeastTreeFromMaster.assembleTree` depends on `Tree.m_nodes` being `null` before calling `Tree.setRoot`. If we want to call `BeastTreeFromMaster.initAndValidate` multiple times (e.g. in `feast.simulation.GpSimulator`), we need to reset `m_nodes` to prevent an `ArrayIndexOutOfBoundsException` when `Tree.setRoot` tries to re-number the root node.